### PR TITLE
Fix swapNames in session-three files

### DIFF
--- a/session-three/exercises/source/enums.c
+++ b/session-three/exercises/source/enums.c
@@ -13,8 +13,8 @@ struct userinfo {
     int (*calc)(int a, int b);
 };
 
-void swapNames(char *a, char*b){
-    char *tmp = malloc(sizeof(a));
+void swapNames(char **a, char **b){
+    char *tmp;
     tmp = *a;
     *a = *b;
     *b = tmp;

--- a/session-three/exercises/source/pointer-struct.c
+++ b/session-three/exercises/source/pointer-struct.c
@@ -72,10 +72,12 @@ int main(int argc, char * argv[])
     for(pwordLen = 0; pwordLen < strlen(info.password);pwordLen++ ){
         if(username[pwordLen] != info.password[pwordLen]){
             printf("Invalid character in password detected, exiting now!\r\n");
+            free(info.password);
             return -1;
         }
     }
 
     printf("Correct! Access granted!\r\n");
+    free(info.password);
     return 0;
 }

--- a/session-three/exercises/source/pointer-struct.c
+++ b/session-three/exercises/source/pointer-struct.c
@@ -11,8 +11,8 @@ struct userinfo {
     int (*calc)(int a, int b);
 };
 
-void swapNames(char *a, char*b){
-    char *tmp = malloc(sizeof(a));
+void swapNames(char **a, char**b){
+    char *tmp;
     tmp = *a;
     *a = *b;
     *b = tmp;
@@ -77,6 +77,5 @@ int main(int argc, char * argv[])
     }
 
     printf("Correct! Access granted!\r\n");
-    free(info.password);
     return 0;
 }


### PR DESCRIPTION
The function `swapNames` in pointers-struct.c and enums.c have an incorrect function signature. If we're swapping what  username and password point to as it seems to be the case when calling the `swapNames` function from `main`, both parameters should be of type `char **` and not `char *`. 

This change also fixes the ELF generated which seems to be swapping just the first character of an address instead of swapping the strings. In reality it only works as both argv[2] and argv[3] are very close and we're just changing the last byte of the address. There could be cases where the addresses of argv[2] and argv[3] have the last two bytes which are different

Also removed unnecessary `malloc` which was also not being `free`d.

Should this pull request be accepted, the relevant binaries would also need to be updated